### PR TITLE
Fix ad service argument and parenthesis errors

### DIFF
--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -403,7 +403,7 @@ class AdService {
 
       // Update mediation metrics for exception
       if (_isMediationEnabled) {
-        _updateMediationMetrics('admob', false, null);
+        _updateMediationMetrics("admob", false, null);
       }
     }
   }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "Too many positional arguments" and "Expected to find ')'" errors by changing string literal quotes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The errors were caused by an invisible character or encoding issue when using single quotes for the `'admob'` string literal on line 406. Replacing single quotes with double quotes resolved the underlying character issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-826f0b32-9d81-4ceb-be4e-f78e1e689b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-826f0b32-9d81-4ceb-be4e-f78e1e689b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>