### PR TITLE
Fix ironsource ad listener overrides

### DIFF
--- a/lib/services/ironsource_service.dart
+++ b/lib/services/ironsource_service.dart
@@ -26,8 +26,12 @@ class IronSourceService {
 
   bool _isInitialized = false;
   bool _isNativeAdLoaded = false;
+  bool _isInterstitialAdLoaded = false;
+  bool _isRewardedAdLoaded = false;
 
   LevelPlayNativeAd? _nativeAd;
+  LevelPlayInterstitialAd? _interstitialAd;
+  LevelPlayRewardedAd? _rewardedAd;
 
   final StreamController<Map<String, dynamic>> _eventController =
       StreamController<Map<String, dynamic>>.broadcast();
@@ -38,6 +42,8 @@ class IronSourceService {
 
   bool get isInitialized => _isInitialized;
   bool get isNativeAdLoaded => _isNativeAdLoaded;
+  bool get isInterstitialAdLoaded => _isInterstitialAdLoaded;
+  bool get isRewardedAdLoaded => _isRewardedAdLoaded;
   Stream<Map<String, dynamic>> get events => _eventController.stream;
 
   Future<void> initialize() async {
@@ -65,8 +71,10 @@ class IronSourceService {
       // Setup event listeners
       _setupEventListeners();
 
-      // Preload native ad
+      // Preload ads
       await _loadNativeAd();
+      await _loadInterstitialAd();
+      await _loadRewardedAd();
     } catch (e) {
       developer.log('IronSource initialization failed: $e',
           name: 'IronSourceService', error: e);
@@ -102,6 +110,44 @@ class IronSourceService {
     }
   }
 
+  Future<void> _loadInterstitialAd() async {
+    if (!_isInitialized) return;
+
+    try {
+      _interstitialAd = LevelPlayInterstitialAd.builder()
+          .withPlacementName(_adUnitIds['interstitial']!)
+          .withListener(_InterstitialAdListener())
+          .build();
+
+      await _interstitialAd?.loadAd();
+      _isInterstitialAdLoaded = true;
+      developer.log('IronSource Interstitial ad loaded', name: 'IronSourceService');
+    } catch (e) {
+      developer.log('IronSource Interstitial ad load failed: $e',
+          name: 'IronSourceService', error: e);
+      _isInterstitialAdLoaded = false;
+    }
+  }
+
+  Future<void> _loadRewardedAd() async {
+    if (!_isInitialized) return;
+
+    try {
+      _rewardedAd = LevelPlayRewardedAd.builder()
+          .withPlacementName(_adUnitIds['rewarded']!)
+          .withListener(_RewardedAdListener())
+          .build();
+
+      await _rewardedAd?.loadAd();
+      _isRewardedAdLoaded = true;
+      developer.log('IronSource Rewarded ad loaded', name: 'IronSourceService');
+    } catch (e) {
+      developer.log('IronSource Rewarded ad load failed: $e',
+          name: 'IronSourceService', error: e);
+      _isRewardedAdLoaded = false;
+    }
+  }
+
   Widget? getNativeAdWidget({
     double height = 350,
     double width = 300,
@@ -131,9 +177,61 @@ class IronSourceService {
     }
   }
 
+  Future<bool> showInterstitialAd() async {
+    if (!_isInitialized || !_isInterstitialAdLoaded || _interstitialAd == null) {
+      developer.log('IronSource Interstitial ad not ready',
+          name: 'IronSourceService');
+      return false;
+    }
+
+    try {
+      await _interstitialAd!.showAd();
+      _adShowCounts['interstitial'] = (_adShowCounts['interstitial'] ?? 0) + 1;
+      developer.log('IronSource Interstitial ad shown', name: 'IronSourceService');
+      return true;
+    } catch (e) {
+      developer.log('IronSource Interstitial ad show failed: $e',
+          name: 'IronSourceService', error: e);
+      _adFailCounts['interstitial'] = (_adFailCounts['interstitial'] ?? 0) + 1;
+      return false;
+    }
+  }
+
+  Future<bool> showRewardedAd() async {
+    if (!_isInitialized || !_isRewardedAdLoaded || _rewardedAd == null) {
+      developer.log('IronSource Rewarded ad not ready',
+          name: 'IronSourceService');
+      return false;
+    }
+
+    try {
+      await _rewardedAd!.showAd();
+      _adShowCounts['rewarded'] = (_adShowCounts['rewarded'] ?? 0) + 1;
+      developer.log('IronSource Rewarded ad shown', name: 'IronSourceService');
+      return true;
+    } catch (e) {
+      developer.log('IronSource Rewarded ad show failed: $e',
+          name: 'IronSourceService', error: e);
+      _adFailCounts['rewarded'] = (_adFailCounts['rewarded'] ?? 0) + 1;
+      return false;
+    }
+  }
+
   Future<void> reloadNativeAd() async {
     if (_nativeAd != null) {
       await _nativeAd!.loadAd();
+    }
+  }
+
+  Future<void> reloadInterstitialAd() async {
+    if (_interstitialAd != null) {
+      await _interstitialAd!.loadAd();
+    }
+  }
+
+  Future<void> reloadRewardedAd() async {
+    if (_rewardedAd != null) {
+      await _rewardedAd!.loadAd();
     }
   }
 
@@ -142,6 +240,22 @@ class IronSourceService {
       await _nativeAd!.destroyAd();
       _nativeAd = null;
       _isNativeAdLoaded = false;
+    }
+  }
+
+  Future<void> destroyInterstitialAd() async {
+    if (_interstitialAd != null) {
+      await _interstitialAd!.destroyAd();
+      _interstitialAd = null;
+      _isInterstitialAdLoaded = false;
+    }
+  }
+
+  Future<void> destroyRewardedAd() async {
+    if (_rewardedAd != null) {
+      await _rewardedAd!.destroyAd();
+      _rewardedAd = null;
+      _isRewardedAdLoaded = false;
     }
   }
 
@@ -163,13 +277,17 @@ class IronSourceService {
   Map<String, dynamic> get metrics => {
         'is_initialized': _isInitialized,
         'native_loaded': _isNativeAdLoaded,
+        'interstitial_loaded': _isInterstitialAdLoaded,
+        'rewarded_loaded': _isRewardedAdLoaded,
         'ad_shows': _adShowCounts,
         'ad_failures': _adFailCounts,
         'revenue': _revenueData,
       };
 
   void dispose() {
-    _nativeAd?.destroyAd();
+    destroyNativeAd();
+    destroyInterstitialAd();
+    destroyRewardedAd();
     _eventController.close();
   }
 
@@ -222,5 +340,88 @@ class _NativeAdListener implements LevelPlayNativeAdListener {
   @override
   void onAdLoaded(LevelPlayNativeAd? nativeAd, IronSourceAdInfo? adInfo) {
     developer.log('IronSource Native ad loaded', name: 'IronSourceService');
+  }
+}
+
+class _InterstitialAdListener implements LevelPlayInterstitialAdListener {
+  @override
+  void onAdClicked(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Interstitial ad clicked', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdClosed() {
+    developer.log('IronSource Interstitial ad closed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayFailed(LevelPlayAdError error) {
+    developer.log('IronSource Interstitial ad display failed: ${error.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayed() {
+    developer.log('IronSource Interstitial ad displayed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdInfoChanged(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Interstitial ad info changed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdLoadFailed(LevelPlayAdError error) {
+    developer.log('IronSource Interstitial ad load failed: ${error.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdLoaded(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Interstitial ad loaded', name: 'IronSourceService');
+  }
+}
+
+class _RewardedAdListener implements LevelPlayRewardedAdListener {
+  @override
+  void onAdClicked(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Rewarded ad clicked', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdClosed() {
+    developer.log('IronSource Rewarded ad closed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayFailed(LevelPlayAdError error) {
+    developer.log('IronSource Rewarded ad display failed: ${error.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayed() {
+    developer.log('IronSource Rewarded ad displayed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdInfoChanged(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Rewarded ad info changed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdLoadFailed(LevelPlayAdError error) {
+    developer.log('IronSource Rewarded ad load failed: ${error.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdLoaded(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Rewarded ad loaded', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdRewarded(LevelPlayAdInfo adInfo) {
+    developer.log('IronSource Rewarded ad rewarded', name: 'IronSourceService');
   }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Complete IronSource Interstitial and Rewarded Ad implementations to resolve compilation errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `ironsource_service.dart` file was incomplete, leading to "undefined method" and "invalid override" errors for Interstitial and Rewarded Ad functionalities. This PR adds the missing builder patterns, `destroyAd` calls, and comprehensive listener implementations to fully support these ad types.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5b156cd-41f9-4a7d-a46f-4d699c5a3997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5b156cd-41f9-4a7d-a46f-4d699c5a3997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>