### PR TITLE
Fix ironsource service method errors

### DIFF
--- a/lib/services/ironsource_service.dart
+++ b/lib/services/ironsource_service.dart
@@ -385,6 +385,22 @@ class _InterstitialAdListener implements LevelPlayInterstitialAdListener {
   }
 
   @override
+  void onAdClosed(LevelPlayInterstitialAd? interstitialAd, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Interstitial ad closed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayFailed(LevelPlayInterstitialAd? interstitialAd, IronSourceError? error, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Interstitial ad display failed: ${error?.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayed(LevelPlayInterstitialAd? interstitialAd, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Interstitial ad displayed', name: 'IronSourceService');
+  }
+
+  @override
   void onAdImpression(LevelPlayInterstitialAd? interstitialAd, IronSourceAdInfo? adInfo) {
     developer.log('IronSource Interstitial ad impression', name: 'IronSourceService');
   }
@@ -416,6 +432,22 @@ class _RewardedAdListener implements LevelPlayRewardedAdListener {
   @override
   void onAdClicked(LevelPlayRewardedAd? rewardedAd, IronSourceAdInfo? adInfo) {
     developer.log('IronSource Rewarded ad clicked', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdClosed(LevelPlayRewardedAd? rewardedAd, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Rewarded ad closed', name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayFailed(LevelPlayRewardedAd? rewardedAd, IronSourceError? error, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Rewarded ad display failed: ${error?.toString()}',
+        name: 'IronSourceService');
+  }
+
+  @override
+  void onAdDisplayed(LevelPlayRewardedAd? rewardedAd, IronSourceAdInfo? adInfo) {
+    developer.log('IronSource Rewarded ad displayed', name: 'IronSourceService');
   }
 
   @override


### PR DESCRIPTION
Update IronSource listener method signatures and add missing `@override` annotations to resolve API compatibility issues.

The previous method signatures for `onAdClosed`, `onAdDisplayFailed`, and `onAdDisplayed` in `_InterstitialAdListener` and `_RewardedAdListener` did not match the updated `LevelPlayInterstitialAdListener` and `LevelPlayRewardedAdListener` interfaces in IronSource mediation version 3.2.0, leading to `invalid_override` errors. This PR updates the signatures to match the new API and ensures proper overriding.

---
<a href="https://cursor.com/background-agent?bcId=bc-443ab56c-d93a-46aa-a8cf-2fb4db1bc0e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-443ab56c-d93a-46aa-a8cf-2fb4db1bc0e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>