### PR TITLE
Fix undefined named parameter in ad service

### DIFF
--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -612,7 +612,6 @@ class AdService {
         final ironSourceWidget = _ironSourceService.getNativeAdWidget(
           height: 360,
           width: 300,
-          templateType: LevelPlayTemplateType.MEDIUM,
         );
         if (ironSourceWidget != null) {
           return Container(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove explicit `templateType` parameter as the `getNativeAdWidget` method uses a default value, resolving an undefined named parameter error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `LevelPlayTemplateType` enum was not being recognized in `ad_service.dart`, causing a compilation error. By removing the explicit parameter, the method now correctly uses its default `LevelPlayTemplateType.MEDIUM`, maintaining functionality without requiring a problematic import.

---
<a href="https://cursor.com/background-agent?bcId=bc-58300968-1e38-4ceb-b7ca-a71293d3b370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58300968-1e38-4ceb-b7ca-a71293d3b370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>