### PR TITLE
Remove undefined adunitid parameter code

### DIFF
--- a/lib/services/ironsource_service.dart
+++ b/lib/services/ironsource_service.dart
@@ -15,11 +15,6 @@ class IronSourceService {
   static const String _androidAppKey = '2314651cd';
   static const String _iosAppKey = '2314651cd';
 
-  // IronSource Ad Unit IDs (from your dashboard)
-  static const String _nativeAdUnitId = 'lcv9s3mjszw657sy';
-  static const String _interstitialAdUnitId = 'i5bc3rl0ebvk8xjk';
-  static const String _rewardedAdUnitId = 'lcv9s3mjszw657sy';
-
   bool _isInitialized = false;
   bool _isNativeAdLoaded = false;
   bool _isInterstitialAdLoaded = false;
@@ -90,9 +85,7 @@ class IronSourceService {
     if (!_isInitialized) return;
 
     try {
-      _nativeAd = LevelPlayNativeAd(
-        adUnitId: _nativeAdUnitId,
-      );
+      _nativeAd = LevelPlayNativeAd();
 
       await _nativeAd?.loadAd();
       _isNativeAdLoaded = true;
@@ -108,9 +101,7 @@ class IronSourceService {
     if (!_isInitialized) return;
 
     try {
-      _interstitialAd = LevelPlayInterstitialAd(
-        adUnitId: _interstitialAdUnitId,
-      );
+      _interstitialAd = LevelPlayInterstitialAd();
 
       await _interstitialAd?.loadAd();
       _isInterstitialAdLoaded = true;
@@ -126,9 +117,7 @@ class IronSourceService {
     if (!_isInitialized) return;
 
     try {
-      _rewardedAd = LevelPlayRewardedAd(
-        adUnitId: _rewardedAdUnitId,
-      );
+      _rewardedAd = LevelPlayRewardedAd();
 
       await _rewardedAd?.loadAd();
       _isRewardedAdLoaded = true;


### PR DESCRIPTION
Remove `adUnitId` parameters from IronSource ad constructors and unused constants to resolve undefined parameter errors and use default ad units.

---
<a href="https://cursor.com/background-agent?bcId=bc-524ad2b2-ae99-4e3c-99a6-f3307fc9c062">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-524ad2b2-ae99-4e3c-99a6-f3307fc9c062">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>